### PR TITLE
Add RubyGems as a source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-gem 'mspec'
+source :rubygems
 
+gem 'mspec'


### PR DESCRIPTION
Bundler will complain it can't find mspec from any
of the sources, as there weren't any.
