### PR TITLE
Update rubymirrors.gemspec

### DIFF
--- a/rubymirrors.gemspec
+++ b/rubymirrors.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Tim Felgentreff"]
   s.email         = ["timfelgentreff@gmail.com"]
   s.summary       = "Mirror API for Ruby"
-  s.description   = File.read(File.expand_path("../README.md", __FILE__))
+  s.description   = "Provides a number of specs and classes that document a mirror API for Ruby."
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
The README as the description looks bad on RubyGems.

![screencap](http://dl.dropbox.com/u/3082549/timfel-rubymirrors-rubygems-description.png)
